### PR TITLE
Fix equals, check uthread_join params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 uthread:
-	g++ --std=c++11 -o uthread uthread.cpp -lrt
+	g++ --std=c++11 -o uthread main.cpp -lrt

--- a/main.cpp
+++ b/main.cpp
@@ -53,6 +53,11 @@ int current_thread_id = -1;
 
 void uthread_yield();
 
+bool valid_tid(int tid){
+    return 0 <= tid && tid < num_threads;
+}
+
+
 /* A translation is required when using an address of a variable.
     Use this as a black box in your code. */
 #ifdef __x86_64__
@@ -239,7 +244,15 @@ int uthread_self(){
     return current_thread_id;
 }
 
+/**
+ * Join against another thread.
+ * @param tid The tid of the thread to join on.
+ * @param retval A pointer which will be set to the return value of the thread.
+ * @return 0 if join was successful, false if tid did not represent a valid thread.
+ */
 int uthread_join(int tid, void **retval){
+    if(!valid_tid(tid)) return -1;
+    if(tid == current_thread_id || threads[tid].complete) return -1;
     threads[current_thread_id].waiting_for_tid = tid;
     thread_switch();
     *retval = threads[tid].result;

--- a/main.cpp
+++ b/main.cpp
@@ -262,7 +262,7 @@ int uthread_self(){
  */
 int uthread_join(int tid, void **retval){
     if(!valid_tid(tid)) return -1;
-    if(tid == current_thread_id || threads[tid].complete) return -1;
+    if(tid == current_thread_id || threads[tid].complete) return 0;
     threads[current_thread_id].waiting_for_tid = tid;
     thread_switch();
     *retval = threads[tid].result;
@@ -301,9 +301,7 @@ ssize_t async_read(int fildes, void *buf, size_t nbytes){
  */
 int uthread_resume(int tid) {
     // Verify that tid is valid
-    if(tid >= num_threads || tid < 0)
-	return -1;
-
+    if(!valid_tid(tid)) return -1;
     std::deque<int>::iterator it;
 
     // Verify that tid is currently suspended
@@ -327,9 +325,7 @@ int uthread_resume(int tid) {
  */
 int uthread_suspend(int tid) {
     // Verify that tid is valid
-    if(tid >= num_threads || tid < 0)
-	return -1;
-
+    if(!valid_tid(tid)) return -1;
     // If tid is complete it can't be suspended
     if(threads[tid].complete) {
 	return -1;
@@ -364,9 +360,7 @@ int uthread_suspend(int tid) {
  */
 int uthread_terminate(int tid) {
     // Verify that tid is valid
-    if(tid >= num_threads || tid < 0)
-	return -1;
-
+    if(!valid_tid(tid)) return -1;
     threads[tid].complete = true;
 
     std::deque<int>::iterator it;

--- a/main.cpp
+++ b/main.cpp
@@ -105,8 +105,8 @@ void free_waiting_threads(int tid) {
     std::deque<int>::iterator end = waiting_list.end();
     while(it != end) {
 	int id = *it;
-	if(threads[id].waiting_for_tid = tid) {
-	    threads[id].waiting_for_tid == -1;
+	if(threads[id].waiting_for_tid == tid) {
+	    threads[id].waiting_for_tid = -1;
 	    waiting_list.erase(it);
 	    ready_list.push_back(id);
 	}


### PR DESCRIPTION
1. Fix the equality check. 
2. Make `uthread_join` check it's tid. 
3. Allow running code after start using sigjmp.

We should also refactor the code to use valid_tid() more,
and split the test cases into each one calling start() to get
some actual isolation of test cases.

Fixes #7