### PR TITLE
reorganize tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-uthread:
+uthread: main.cpp
 	g++ --std=c++11 -o uthread main.cpp -lrt


### PR DESCRIPTION
This reorganizes each test to call `start`, so that they are isolated.
I also changed the loops in the tests to run for just 5 iterations rather than 100.
The original reason was to see the effect of several threads running for a long time,
but its sufficient to see them run for very few iterations.

Also, I fixed the Makefile.

@kstowe Thoughts?